### PR TITLE
Allow SSL in referer checking

### DIFF
--- a/roles/apache/templates/common.conf.j2
+++ b/roles/apache/templates/common.conf.j2
@@ -24,7 +24,7 @@ ProxyPassReverse /gateway http://localhost:{{ tomcat_instances['proxycas']['port
 ProxyPass /testPage http://localhost:{{ tomcat_instances['proxycas']['port'] }}/testPage
 ProxyPassReverse /testPage http://localhost:{{ tomcat_instances['proxycas']['port'] }}/testPage
 
-SetEnvIf Referer "^http://{{ georchestra.fqdn|replace('.','\.') }}/" mysdi
+SetEnvIf Referer "^http(s)?://{{ georchestra.fqdn|replace('.','\.') }}/" mysdi
 {% endif %}
 <Proxy http://localhost:{{ tomcat_instances['proxycas']['port'] }}/{{ item.dest }}/*>
 {% if item.dest != 'proxy' %}


### PR DESCRIPTION
... or mapfishapp fails to load external servers because accessing the proxy is not allowed.